### PR TITLE
Remember time between sessions

### DIFF
--- a/Stopwatch/PropertyInspector/Stopwatch/Index.html
+++ b/Stopwatch/PropertyInspector/Stopwatch/Index.html
@@ -21,6 +21,11 @@
             <input class="sdpi-item-value sdProperty" placeholder="c:\temp\timer.txt" value="" id="fileName">
             <button class="sdpi-item-value max20 minmargin" onclick="setSettings()">Save</button>
         </div>
+        <div class="sdpi-item" id="dvStartTime">
+            <div class="sdpi-item-label">Start Time</div>
+            <input class="sdpi-item-value sdProperty" placeholder="00:00:00" value="" id="startTime">
+            <button class="sdpi-item-value max20 minmargin" onclick="setSettings()">Save</button>
+        </div>
         <div type="checkbox" class="sdpi-item" id="dvClearFileOnReset">
             <div class="sdpi-item-label">Clear on Reset</div>
             <div class="sdpi-item-value">

--- a/Stopwatch/Stopwatch.csproj
+++ b/Stopwatch/Stopwatch.csproj
@@ -35,28 +35,25 @@
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CommandLine, Version=2.7.82.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
-      <HintPath>..\..\..\DotNet\StreamDeck\packages\CommandLineParser.2.7.82\lib\net461\CommandLine.dll</HintPath>
+    <Reference Include="CommandLine, Version=2.8.0.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
+      <HintPath>..\packages\CommandLineParser.2.8.0\lib\net461\CommandLine.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\..\DotNet\StreamDeck\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\..\..\DotNet\StreamDeck\packages\NLog.4.7.0\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.4.7.3\lib\net45\NLog.dll</HintPath>
     </Reference>
-    <Reference Include="streamdeck-client-csharp, Version=4.1.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\DotNet\StreamDeck\packages\streamdeck-client-csharp.4.1.1\lib\netstandard2.0\streamdeck-client-csharp.dll</HintPath>
+    <Reference Include="streamdeck-client-csharp, Version=4.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\streamdeck-client-csharp.4.2.0\lib\netstandard2.0\streamdeck-client-csharp.dll</HintPath>
     </Reference>
-    <Reference Include="StreamDeckTools, Version=2.8.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\DotNet\StreamDeck\packages\StreamDeck-Tools.2.8.0\lib\net472\StreamDeckTools.dll</HintPath>
+    <Reference Include="StreamDeckTools, Version=2.9.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\StreamDeck-Tools.2.9.0\lib\net472\StreamDeckTools.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Drawing.Common, Version=4.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\DotNet\StreamDeck\packages\System.Drawing.Common.4.7.0\lib\net461\System.Drawing.Common.dll</HintPath>
-    </Reference>
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />

--- a/Stopwatch/Stopwatch.csproj
+++ b/Stopwatch/Stopwatch.csproj
@@ -73,6 +73,7 @@
     <Compile Include="StopwatchSettings.cs" />
     <Compile Include="StopwatchStatus.cs" />
     <Compile Include="StopwatchTimerAction.cs" />
+    <Compile Include="StopwatchWithOffset.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/Stopwatch/StopwatchManager.cs
+++ b/Stopwatch/StopwatchManager.cs
@@ -58,7 +58,6 @@ namespace Stopwatch
 
         public void StartStopwatch(StopwatchSettings settings)
         {
-            InitializeStopwatch(settings);
             if (settings.ResetOnStart)
             {
                 ResetStopwatch(settings);
@@ -76,7 +75,6 @@ namespace Stopwatch
 
         public void ResetStopwatch(StopwatchSettings settings)
         {
-            InitializeStopwatch(settings);
             dicCounters[settings.StopwatchId].Stopwatch.Reset();
             dicCounters[settings.StopwatchId].Laps.Clear();
 
@@ -164,29 +162,30 @@ namespace Stopwatch
             }
         }
 
-        private void InitializeStopwatch(StopwatchSettings settings)
+        public void InitializeStopwatch(StopwatchSettings settings)
         {
             string stopwatchId = settings.StopwatchId;
             if (!dicCounters.ContainsKey(stopwatchId))
             {
                 dicCounters[stopwatchId] = new StopwatchStatus();
-
-                var times = settings.StartTime.Split(':');
-                if (!int.TryParse(times[0], out int hours))
-                {
-                    hours = 0;
-                }
-                if (!int.TryParse(times[1], out int minutes))
-                {
-                    minutes = 0;
-                }
-                if (!int.TryParse(times[2], out int seconds))
-                {
-                    seconds = 0;
-                }
-                dicCounters[stopwatchId].Stopwatch.StartOffset = new TimeSpan(hours, minutes, seconds);
             }
 
+            var times = settings.StartTime.Split(':');
+            if (!int.TryParse(times[0], out int hours))
+            {
+                hours = 0;
+            }
+            if (!int.TryParse(times[1], out int minutes))
+            {
+                minutes = 0;
+            }
+            if (!int.TryParse(times[2], out int seconds))
+            {
+                seconds = 0;
+            }
+
+            dicCounters[stopwatchId].Stopwatch.Reset();
+            dicCounters[stopwatchId].Stopwatch.StartOffset = new TimeSpan(hours, minutes, seconds);
             dicCounters[stopwatchId].Filename = settings.FileName;
             dicCounters[stopwatchId].ClearFileOnReset = settings.ClearFileOnReset;
             dicCounters[stopwatchId].LapMode = settings.LapMode;

--- a/Stopwatch/StopwatchManager.cs
+++ b/Stopwatch/StopwatchManager.cs
@@ -146,7 +146,7 @@ namespace Stopwatch
             }
 
             TimeSpan ts = stopwatchDate.Stopwatch.Elapsed;
-            SaveTimerToFile(stopwatchDate.Filename, $"{ts.Hours:00}:{ts.Minutes:00}:{ts.Seconds:00}");
+            SaveTimerToFile(stopwatchDate.Filename, $"{(int)ts.TotalHours:00}:{ts.Minutes:00}:{ts.Seconds:00}");
         }
 
         private void SaveTimerToFile(string fileName, string text)

--- a/Stopwatch/StopwatchManager.cs
+++ b/Stopwatch/StopwatchManager.cs
@@ -83,7 +83,7 @@ namespace Stopwatch
             // Clear file contents
             if (settings.ClearFileOnReset)
             {
-                SaveTimerToFile(settings.FileName, "");
+                SaveTimerToFile(settings.FileName, "00:00:00");
             }
         }
 
@@ -116,9 +116,9 @@ namespace Stopwatch
             return dicCounters[stopwatchId].Stopwatch.IsRunning;
         }
 
-        public void TouchTimerFile(string filename)
+        public void TouchTimerFile(string filename, string startTime)
         {
-            SaveTimerToFile(filename, "00:00:00");
+            SaveTimerToFile(filename, startTime);
         }
 
         #endregion
@@ -170,6 +170,21 @@ namespace Stopwatch
             if (!dicCounters.ContainsKey(stopwatchId))
             {
                 dicCounters[stopwatchId] = new StopwatchStatus();
+
+                var times = settings.StartTime.Split(':');
+                if (!int.TryParse(times[0], out int hours))
+                {
+                    hours = 0;
+                }
+                if (!int.TryParse(times[1], out int minutes))
+                {
+                    minutes = 0;
+                }
+                if (!int.TryParse(times[2], out int seconds))
+                {
+                    seconds = 0;
+                }
+                dicCounters[stopwatchId].Stopwatch.StartOffset = new TimeSpan(hours, minutes, seconds);
             }
 
             dicCounters[stopwatchId].Filename = settings.FileName;

--- a/Stopwatch/StopwatchSettings.cs
+++ b/Stopwatch/StopwatchSettings.cs
@@ -17,5 +17,7 @@ namespace Stopwatch
         internal bool LapMode { get; set; }
 
         internal string FileName { get; set; }
+
+        internal string StartTime { get; set; }
     }
 }

--- a/Stopwatch/StopwatchStatus.cs
+++ b/Stopwatch/StopwatchStatus.cs
@@ -9,7 +9,7 @@ namespace Stopwatch
 {
     public class StopwatchStatus
     {
-        public System.Diagnostics.Stopwatch Stopwatch { get; set; }
+        public StopwatchWithOffset Stopwatch { get; set; }
 
         public string Filename { get; set; }
 
@@ -21,7 +21,7 @@ namespace Stopwatch
 
         public StopwatchStatus()
         {
-            Stopwatch = new System.Diagnostics.Stopwatch();
+            Stopwatch = new StopwatchWithOffset(new TimeSpan(0));
             Filename = String.Empty;
             ClearFileOnReset = false;
             Laps = new List<TimeSpan>();

--- a/Stopwatch/StopwatchStatus.cs
+++ b/Stopwatch/StopwatchStatus.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -8,9 +9,7 @@ namespace Stopwatch
 {
     public class StopwatchStatus
     {
-        public long Counter { get; set; }
-
-        public bool IsEnabled { get; set; }
+        public System.Diagnostics.Stopwatch Stopwatch { get; set; }
 
         public string Filename { get; set; }
 
@@ -18,15 +17,14 @@ namespace Stopwatch
 
         public bool ClearFileOnReset { get; set; }
 
-        public List<long> Laps { get; set; }
+        public List<TimeSpan> Laps { get; set; }
 
         public StopwatchStatus()
         {
-            Counter = 0;
-            IsEnabled = false;
+            Stopwatch = new System.Diagnostics.Stopwatch();
             Filename = String.Empty;
             ClearFileOnReset = false;
-            Laps = new List<long>();
+            Laps = new List<TimeSpan>();
         }
     }
 }

--- a/Stopwatch/StopwatchTimerAction.cs
+++ b/Stopwatch/StopwatchTimerAction.cs
@@ -205,7 +205,6 @@ namespace Stopwatch
             t.Join();
         }
 
-        
         private void PauseStopwatch()
         {
             Stopwatch.StopwatchManager.Instance.StopStopwatch(stopwatchId);

--- a/Stopwatch/StopwatchTimerAction.cs
+++ b/Stopwatch/StopwatchTimerAction.cs
@@ -180,7 +180,7 @@ namespace Stopwatch
 
                     foreach (TimeSpan lap in laps)
                     {
-                        lapStr.Add(TimeSpanToReadableFormat(lap, ":", false));
+                        lapStr.Add(TimeSpanToReadableFormat(lap, ":"));
                     }
                     SaveToClipboard(string.Join("\n", lapStr.ToArray()));
                 }
@@ -211,9 +211,9 @@ namespace Stopwatch
             Stopwatch.StopwatchManager.Instance.StopStopwatch(stopwatchId);
         }
 
-        private string TimeSpanToReadableFormat(TimeSpan ts, string delimiter, bool secondsOnNewLine)
+        private string TimeSpanToReadableFormat(TimeSpan ts, string delimiter)
         {
-            return $"{ts.Hours:00}{delimiter}{ts.Minutes:00}{(secondsOnNewLine ? "\n" : delimiter)}{ts.Seconds:00}";
+            return $"{ts.Hours:00}{delimiter}{ts.Minutes:00}{delimiter}{ts.Seconds:00}";
         }
 
         private async void TmrOnTick_Elapsed(object sender, ElapsedEventArgs e)
@@ -225,7 +225,7 @@ namespace Stopwatch
             CheckIfResetNeeded();
 
             TimeSpan ts = StopwatchManager.Instance.GetStopwatchTime(stopwatchId);
-            await Connection.SetTitleAsync(TimeSpanToReadableFormat(ts, delimiter, true));
+            await Connection.SetTitleAsync(TimeSpanToReadableFormat(ts, delimiter));
         }
 
         #endregion

--- a/Stopwatch/StopwatchTimerAction.cs
+++ b/Stopwatch/StopwatchTimerAction.cs
@@ -31,7 +31,8 @@ namespace Stopwatch
                     Multiline = false,
                     ClearFileOnReset = false,
                     LapMode = false,
-                    FileName = String.Empty
+                    FileName = String.Empty,
+                    StartTime = "00:00:00"
                 };
 
                 return instance;
@@ -45,6 +46,9 @@ namespace Stopwatch
 
             [JsonProperty(PropertyName = "fileName")]
             public string FileName { get; set; }
+
+            [JsonProperty(PropertyName = "startTime")]
+            public string StartTime { get; set; }
 
             [JsonProperty(PropertyName = "clearFileOnReset")]
             public bool ClearFileOnReset { get; set; }
@@ -94,7 +98,7 @@ namespace Stopwatch
 
             if (fileName != settings.FileName)
             {
-                StopwatchManager.Instance.TouchTimerFile(settings.FileName);
+                StopwatchManager.Instance.TouchTimerFile(settings.FileName, settings.StartTime);
             }
         }
 
@@ -153,12 +157,12 @@ namespace Stopwatch
 
         private void ResetCounter()
         {
-            StopwatchManager.Instance.ResetStopwatch(new StopwatchSettings() { StopwatchId = stopwatchId, FileName = settings.FileName, ClearFileOnReset = settings.ClearFileOnReset, LapMode = settings.LapMode, ResetOnStart = !settings.ResumeOnClick });
+            StopwatchManager.Instance.ResetStopwatch(new StopwatchSettings() { StopwatchId = stopwatchId, FileName = settings.FileName, StartTime = settings.StartTime, ClearFileOnReset = settings.ClearFileOnReset, LapMode = settings.LapMode, ResetOnStart = !settings.ResumeOnClick });
         }
 
         private void ResumeStopwatch()
         {
-            StopwatchManager.Instance.StartStopwatch(new StopwatchSettings() { StopwatchId = stopwatchId, FileName = settings.FileName, ClearFileOnReset = settings.ClearFileOnReset, LapMode = settings.LapMode, ResetOnStart = !settings.ResumeOnClick });
+            StopwatchManager.Instance.StartStopwatch(new StopwatchSettings() { StopwatchId = stopwatchId, FileName = settings.FileName, StartTime = settings.StartTime, ClearFileOnReset = settings.ClearFileOnReset, LapMode = settings.LapMode, ResetOnStart = !settings.ResumeOnClick });
         }
 
         private void CheckIfResetNeeded()

--- a/Stopwatch/StopwatchTimerAction.cs
+++ b/Stopwatch/StopwatchTimerAction.cs
@@ -175,16 +175,16 @@ namespace Stopwatch
                 PauseStopwatch();
                 if (settings.LapMode)
                 {
-                    List<long> laps = StopwatchManager.Instance.GetLaps(stopwatchId);
+                    List<TimeSpan> laps = StopwatchManager.Instance.GetLaps(stopwatchId);
                     List<string> lapStr = new List<string>();
 
-                    foreach (long lap in laps)
+                    foreach (TimeSpan lap in laps)
                     {
-                        lapStr.Add(SecondsToReadableFormat(lap, ":", false));
+                        lapStr.Add(TimeSpanToReadableFormat(lap, ":", false));
                     }
                     SaveToClipboard(string.Join("\n", lapStr.ToArray()));
-
                 }
+
                 ResetCounter();
             }
         }
@@ -211,15 +211,9 @@ namespace Stopwatch
             Stopwatch.StopwatchManager.Instance.StopStopwatch(stopwatchId);
         }
 
-        private string SecondsToReadableFormat(long total, string delimiter, bool secondsOnNewLine)
+        private string TimeSpanToReadableFormat(TimeSpan ts, string delimiter, bool secondsOnNewLine)
         {
-            long minutes, seconds, hours;
-            minutes = total / 60;
-            seconds = total % 60;
-            hours = minutes / 60;
-            minutes %= 60;
-
-            return $"{hours.ToString("00")}{delimiter}{minutes.ToString("00")}{(secondsOnNewLine ? "\n" : delimiter)}{seconds.ToString("00")}";
+            return $"{ts.Hours:00}{delimiter}{ts.Minutes:00}{(secondsOnNewLine ? "\n" : delimiter)}{ts.Seconds:00}";
         }
 
         private async void TmrOnTick_Elapsed(object sender, ElapsedEventArgs e)
@@ -230,8 +224,8 @@ namespace Stopwatch
             // so this is the best place to determine if we need to reset (versus the internal timer which may be paused)
             CheckIfResetNeeded();
 
-            long total = StopwatchManager.Instance.GetStopwatchTime(stopwatchId);
-            await Connection.SetTitleAsync(SecondsToReadableFormat(total, delimiter, true));
+            TimeSpan ts = StopwatchManager.Instance.GetStopwatchTime(stopwatchId);
+            await Connection.SetTitleAsync(TimeSpanToReadableFormat(ts, delimiter, true));
         }
 
         #endregion

--- a/Stopwatch/StopwatchTimerAction.cs
+++ b/Stopwatch/StopwatchTimerAction.cs
@@ -216,7 +216,7 @@ namespace Stopwatch
 
         private string TimeSpanToReadableFormat(TimeSpan ts, string delimiter)
         {
-            return $"{ts.Hours:00}{delimiter}{ts.Minutes:00}{delimiter}{ts.Seconds:00}";
+            return $"{(int)ts.TotalHours:00}{delimiter}{ts.Minutes:00}{delimiter}{ts.Seconds:00}";
         }
 
         private async void TmrOnTick_Elapsed(object sender, ElapsedEventArgs e)

--- a/Stopwatch/StopwatchTimerAction.cs
+++ b/Stopwatch/StopwatchTimerAction.cs
@@ -85,6 +85,8 @@ namespace Stopwatch
             }
             stopwatchId = Connection.ContextId;
 
+            StopwatchManager.Instance.InitializeStopwatch(new StopwatchSettings() { StopwatchId = stopwatchId, FileName = settings.FileName, StartTime = settings.StartTime, ClearFileOnReset = settings.ClearFileOnReset, LapMode = settings.LapMode, ResetOnStart = !settings.ResumeOnClick });
+
             tmrOnTick.Interval = 250;
             tmrOnTick.Elapsed += TmrOnTick_Elapsed;
             tmrOnTick.Start();
@@ -100,6 +102,8 @@ namespace Stopwatch
             {
                 StopwatchManager.Instance.TouchTimerFile(settings.FileName, settings.StartTime);
             }
+
+            StopwatchManager.Instance.InitializeStopwatch(new StopwatchSettings() { StopwatchId = stopwatchId, FileName = settings.FileName, StartTime = settings.StartTime, ClearFileOnReset = settings.ClearFileOnReset, LapMode = settings.LapMode, ResetOnStart = !settings.ResumeOnClick });
         }
 
         public override void ReceivedGlobalSettings(ReceivedGlobalSettingsPayload payload)

--- a/Stopwatch/StopwatchTimerAction.cs
+++ b/Stopwatch/StopwatchTimerAction.cs
@@ -124,6 +124,9 @@ namespace Stopwatch
                 else
                 {
                     PauseStopwatch();
+                    TimeSpan ts = StopwatchManager.Instance.GetStopwatchTime(stopwatchId);
+                    settings.StartTime = TimeSpanToReadableFormat(ts, ":");
+                    SaveSettings();
                 }
             }
             else // Stopwatch is already paused
@@ -154,6 +157,11 @@ namespace Stopwatch
         #endregion
 
         #region Private methods
+
+        private Task SaveSettings()
+        {
+            return Connection.SetSettingsAsync(JObject.FromObject(settings));
+        }
 
         private void ResetCounter()
         {

--- a/Stopwatch/StopwatchWithOffset.cs
+++ b/Stopwatch/StopwatchWithOffset.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Stopwatch
+{
+    public class StopwatchWithOffset : System.Diagnostics.Stopwatch
+    {
+        public TimeSpan StartOffset { get; private set; }
+
+        public StopwatchWithOffset(TimeSpan startOffset)
+        {
+            StartOffset = startOffset;
+        }
+
+        public new TimeSpan Elapsed
+        {
+            get
+            {
+                return base.Elapsed.Add(StartOffset);
+            }
+        }
+
+        public new void Reset()
+        {
+            StartOffset = new TimeSpan(0);
+            base.Reset();
+        }
+    }
+}

--- a/Stopwatch/StopwatchWithOffset.cs
+++ b/Stopwatch/StopwatchWithOffset.cs
@@ -8,7 +8,7 @@ namespace Stopwatch
 {
     public class StopwatchWithOffset : System.Diagnostics.Stopwatch
     {
-        public TimeSpan StartOffset { get; private set; }
+        public TimeSpan StartOffset { get; set; }
 
         public StopwatchWithOffset(TimeSpan startOffset)
         {

--- a/Stopwatch/packages.config
+++ b/Stopwatch/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommandLineParser" version="2.7.82" targetFramework="net472" />
+  <package id="CommandLineParser" version="2.8.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472" />
-  <package id="NLog" version="4.7.0" targetFramework="net472" />
-  <package id="streamdeck-client-csharp" version="4.1.1" targetFramework="net472" />
-  <package id="StreamDeck-Tools" version="2.8.0" targetFramework="net472" />
+  <package id="NLog" version="4.7.3" targetFramework="net472" />
+  <package id="streamdeck-client-csharp" version="4.2.0" targetFramework="net472" />
+  <package id="StreamDeck-Tools" version="2.9.0" targetFramework="net472" />
   <package id="System.Drawing.Common" version="4.7.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
A new setting called Start Time is introduced which sets what time the stopwatch should start at. This start time can be manually changed via settings, and is automatically changed to the current stopwatch time when pausing the stopwatch.

The timer have also changed from a long number to .NET Stopwatch.