### PR TITLE
v1.8 - Millisecond support + More formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@ A C# Stopwatch implementation for the Elgato Stream Deck device.
 
 **Author's website and contact information:** [https://barraider.github.io](https://barraider.github.io)
 
+## New in v1.8
+
+* New milliseconds support for greater accuracy
+* Choose from 10 different `time formats` to display as much or as less detail on the key as needed. 🔥
+* New `File Title Prefix` setting allows to set chosen text before the time when saved to file (great to show some text before the time on stream!)
+
 ## New in v1.7
 *Our faithful Stopwatch plugin coming back with a much needed overhaul:*
 - Visual indication if the stopwatch is running or stopped

--- a/Stopwatch/App.config
+++ b/Stopwatch/App.config
@@ -9,7 +9,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Drawing.Common" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.2" newVersion="4.0.0.2" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Stopwatch/Backend/HelperUtils.cs
+++ b/Stopwatch/Backend/HelperUtils.cs
@@ -1,0 +1,78 @@
+﻿using BarRaider.SdTools;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Stopwatch.Backend
+{
+    internal static class HelperUtils
+    {
+        internal const string DEFAULT_TIME_FORMAT = "hh:mm:ss";
+        internal static string FormatTime(long timeInMiliseconds, string timeFormat, bool setNewLineDelimiter)
+        {
+            string delimiter = setNewLineDelimiter ? "\n" : ":";
+            var ts = TimeSpan.FromMilliseconds(timeInMiliseconds);
+
+            string output;
+            long hours = ts.Days * 24 + ts.Hours;
+            long minutes = hours * 60 + ts.Minutes;
+            long seconds = minutes * 60 + ts.Seconds;
+            long ms = ts.Milliseconds;
+            switch (timeFormat)
+            {
+                case "d.hh":
+                    output = (ts.Days > 0) ? $"{ts.Days:0}.{ts.Hours:00}" : $"{ts.Hours:00}";
+                    break;
+                case "d.h:mm":
+                    output = (ts.Days > 0) ? $"{ts.Days:0}.{ts.Hours:00}{delimiter}{ts.Minutes:00}" : $"{ts.Hours:0}{delimiter}{ts.Minutes:00}";
+                    break;
+                case "d.hh:mm":
+                    output = (ts.Days > 0) ? $"{ts.Days:0}.{ts.Hours:00}{delimiter}{ts.Minutes:00}" : $"{ts.Hours:00}{delimiter}{ts.Minutes:00}";
+                    break;
+                case "hh:mm:ss":
+                    output = (hours > 0) ? $"{hours:00}{delimiter}{ts.Minutes:00}{delimiter}{ts.Seconds:00}" : $"{ts.Minutes:00}{delimiter}{ts.Seconds:00}";
+                    break;
+                case "h:mm:ss":
+                    output = (hours > 0) ? $"{hours:0}{delimiter}{ts.Minutes:00}{delimiter}{ts.Seconds:00}" : $"{ts.Minutes:00}{delimiter}{ts.Seconds:00}";
+                    break;
+                case "hh:mm":
+                    output = $"{hours:00}{delimiter}{ts.Minutes:00}";
+                    break;
+                case "mm:ss":
+                    output = $"{minutes:00}{delimiter}{ts.Seconds:00}";
+                    break;
+                case "mm:ss.ms":
+                    output = $"{minutes:00}{delimiter}{ts.Seconds:00}.{ms}";
+                    break;
+                case "ss":
+                    output = $"{seconds:0}";
+                    break;
+                case "ss.ms":
+                    output = $"{seconds:0}.{ms}";
+                    break;
+                default:
+                    Logger.Instance.LogMessage(TracingLevel.WARN, $"FormatTime: Invalid Format {timeFormat}");
+                    return null;
+            }
+            return output;
+        }
+
+        internal static void WriteToFile(string fileName, string text)
+        {
+            try
+            {
+                if (!String.IsNullOrWhiteSpace(fileName))
+                {
+                    File.WriteAllText(fileName, text);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Instance.LogMessage(TracingLevel.ERROR, $"Error Saving value: {text} to counter file: {fileName} : {ex}");
+            }
+        }
+    }
+}

--- a/Stopwatch/Backend/StopwatchManager.cs
+++ b/Stopwatch/Backend/StopwatchManager.cs
@@ -91,7 +91,7 @@ namespace Stopwatch.Backend
 
         public void RecordLap(string stopwatchId)
         {
-            dicCounters[stopwatchId].Laps.Add(GetStopwatchTime(stopwatchId));
+            dicCounters[stopwatchId].Laps.Add(GetStopwatchTimeInMiliseconds(stopwatchId));
         }
 
         public List<long> GetLaps(string stopwatchId)
@@ -99,13 +99,13 @@ namespace Stopwatch.Backend
             return dicCounters[stopwatchId].Laps;
         }
 
-        public long GetStopwatchTime(string stopwatchId)
+        public long GetStopwatchTimeInMiliseconds(string stopwatchId)
         {
             if (!dicCounters.ContainsKey(stopwatchId))
             {
                 return 0;
             }
-            return dicCounters[stopwatchId].GetSeconds();
+            return dicCounters[stopwatchId].GetMiliseconds();
         }
 
         public bool IsStopwatchEnabled(string stopwatchId)
@@ -119,7 +119,7 @@ namespace Stopwatch.Backend
 
         public void TouchTimerFile(string filename)
         {
-            SaveTimerToFile(filename, "00:00");
+            SaveTimerToFile(filename, $"00:00");
         }
 
         #endregion
@@ -139,23 +139,16 @@ namespace Stopwatch.Backend
 
         private void WriteTimerToFile(string counterKey)
         {
-            long total, minutes, seconds, hours;
-            var stopwatchDate = dicCounters[counterKey];
+            var stopwatchData = dicCounters[counterKey];
 
-            if (String.IsNullOrEmpty(stopwatchDate.Filename))
+            if (String.IsNullOrEmpty(stopwatchData.Filename))
             {
                 return;
             }
 
 
-            total = stopwatchDate.GetSeconds();
-            minutes = total / 60;
-            seconds = total % 60;
-            hours = minutes / 60;
-            minutes %= 60;
-
-            string hoursStr = (hours > 0) ? $"{hours.ToString("00")}:" : "";
-            SaveTimerToFile(stopwatchDate.Filename, $"{hoursStr}{minutes.ToString("00")}:{seconds.ToString("00")}");
+            var total = stopwatchData.GetMiliseconds();
+            SaveTimerToFile(stopwatchData.Filename, $"{stopwatchData.FileTitlePrefix}{HelperUtils.FormatTime(total, stopwatchData.TimeFormat, false)}");
         }
 
         private void SaveTimerToFile(string fileName, string text)
@@ -183,8 +176,10 @@ namespace Stopwatch.Backend
             }
 
             dicCounters[stopwatchId].Filename = settings.FileName;
+            dicCounters[stopwatchId].FileTitlePrefix = settings.FileTitlePrefix;
             dicCounters[stopwatchId].ClearFileOnReset = settings.ClearFileOnReset;
             dicCounters[stopwatchId].LapMode = settings.LapMode;
+            dicCounters[stopwatchId].TimeFormat = settings.TimeFormat;
         }
 
         #endregion

--- a/Stopwatch/Backend/StopwatchSettings.cs
+++ b/Stopwatch/Backend/StopwatchSettings.cs
@@ -17,5 +17,9 @@ namespace Stopwatch.Backend
         internal bool LapMode { get; set; }
 
         internal string FileName { get; set; }
+
+        internal string TimeFormat { get; set; }
+
+        internal string FileTitlePrefix { get; set; }
     }
 }

--- a/Stopwatch/Backend/StopwatchStatus.cs
+++ b/Stopwatch/Backend/StopwatchStatus.cs
@@ -13,11 +13,15 @@ namespace Stopwatch.Backend
 
         public string Filename { get; set; }
 
+        public string FileTitlePrefix { get; set; }
+
         public bool LapMode { get; set; }
 
         public bool ClearFileOnReset { get; set; }
 
         public List<long> Laps { get; set; }
+
+        public string TimeFormat { get; set; }
 
         private System.Diagnostics.Stopwatch sw = new System.Diagnostics.Stopwatch();
 
@@ -26,11 +30,19 @@ namespace Stopwatch.Backend
             Filename = String.Empty;
             ClearFileOnReset = false;
             Laps = new List<long>();
+            TimeFormat = HelperUtils.DEFAULT_TIME_FORMAT;
+            FileTitlePrefix = String.Empty;
+
         }
 
         public long GetSeconds()
         {
             return (long)sw.Elapsed.TotalSeconds;
+        }
+
+        public long GetMiliseconds()
+        {
+            return (long)sw.Elapsed.TotalMilliseconds;
         }
 
         public void Start()

--- a/Stopwatch/Program.cs
+++ b/Stopwatch/Program.cs
@@ -1,8 +1,6 @@
 ﻿using BarRaider.SdTools;
 using BRUtils;
-using CommandLine;
 using System;
-using System.Collections.Generic;
 
 namespace Stopwatch
 {

--- a/Stopwatch/Program.cs
+++ b/Stopwatch/Program.cs
@@ -1,4 +1,5 @@
 ﻿using BarRaider.SdTools;
+using BRUtils;
 using CommandLine;
 using System;
 using System.Collections.Generic;
@@ -13,7 +14,7 @@ namespace Stopwatch
             // Uncomment this line of code to allow for debugging
             //while (!System.Diagnostics.Debugger.IsAttached) { System.Threading.Thread.Sleep(100); }
 
-            SDWrapper.Run(args);
+            SDWrapper.Run(args, new UpdateHandler());
         }
     }
 }

--- a/Stopwatch/PropertyInspector/Stopwatch/Stopwatch.html
+++ b/Stopwatch/PropertyInspector/Stopwatch/Stopwatch.html
@@ -6,9 +6,9 @@
     <meta name=apple-mobile-web-app-capable content=yes>
     <meta name=apple-mobile-web-app-status-bar-style content=black>
     <title>BarRaider's Stopwatch</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/barraider/streamdeck-easypi@latest/src/sdpi.css">
-    <script src="https://cdn.jsdelivr.net/gh/barraider/streamdeck-easypi@latest/src/sdtools.common.js"></script>
-    <script src="https://cdn.jsdelivr.net/gh/barraider/streamdeck-easypi@latest/src/pickers.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/barraider/streamdeck-easypi-v2@latest/src/sdpi.css">
+    <script src="https://cdn.jsdelivr.net/gh/barraider/streamdeck-easypi-v2@latest/src/sdtools.common.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/barraider/streamdeck-easypi-v2@latest/src/pickers.js"></script>
 
 </head>
 <body>
@@ -19,17 +19,21 @@
         <details class="message">
             <summary>Tip: Long press resets the stopwatch</summary>
         </details>
-        <div class="sdpi-item" id="dvFileName">
-            <div class="sdpi-item-label">Save to file</div>
-            <input class="sdpi-item-value sdProperty hasFileButton" disabled value="" id="fileName">
-            <button class="max100 leftMargin0" onclick="openSaveFilePicker('Stopwatch File Name', 'Text files (*.txt)|*.txt|All files (*.*)|*.*', 'fileName');">...</button>
-        </div>
-        <div type="checkbox" class="sdpi-item" id="dvClearFileOnReset">
-            <div class="sdpi-item-label">Clear on Reset</div>
-            <div class="sdpi-item-value">
-                <input id="clearFileOnReset" type="checkbox" value="" class="sdProperty sdCheckbox" oninput="setSettings()">
-                <label for="clearFileOnReset" class="sdpi-item-label"><span></span>Clear text file on reset</label>
-            </div>
+        <div class="sdpi-heading">DISPLAY FORMAT</div>
+        <div class="sdpi-item" id="dvTimeFormat">
+            <div class="sdpi-item-label">Format</div>
+            <select class="sdpi-item-value select sdProperty" id="timeFormat" oninput="setSettings()" value="hh:mm:ss">
+                <option value="d.hh">[d.]hh</option>
+                <option value="d.h:mm">[d.]h:mm</option>
+                <option value="d.hh:mm">[d.]hh:mm</option>
+                <option value="hh:mm:ss" selected>[hh:]mm:ss</option>
+                <option value="h:mm:ss">[h:]mm:ss</option>
+                <option value="hh:mm">hh:mm</option>
+                <option value="mm:ss">mm:ss</option>
+                <option value="mm:ss.ms">mm:ss.ms</option>
+                <option value="ss">ss</option>
+                <option value="ss.ms">ss.ms</option>
+            </select>
         </div>
         <div type="checkbox" class="sdpi-item" id="dvMultilineStopwatch">
             <div class="sdpi-item-label">Multiline</div>
@@ -38,6 +42,7 @@
                 <label for="multiline" class="sdpi-item-label"><span></span>3 different lines</label>
             </div>
         </div>
+        <div class="sdpi-heading">BEHAVIOUR</div>
         <div type="checkbox" class="sdpi-item" id="dvClickResume">
             <div class="sdpi-item-label">Resume on click</div>
             <div class="sdpi-item-value">
@@ -56,6 +61,25 @@
             <summary>For 'Lap Mode' usage instructions <span class="linkspan"> CLICK HERE</span></summary>
             <p>In Lap mode, each press records a lap, Long press stops. After a long press, all laps are copied to clipboard</p>
         </details>
+        <div class="sdpi-heading">FILE SETTINGS</div>
+        <div class="sdpi-item" id="dvFileName">
+            <div class="sdpi-item-label">Save to file</div>
+            <input class="sdpi-item-value sdProperty hasFileButton" disabled value="" id="fileName">
+            <button class="max100 leftMargin0" onclick="openSaveFilePicker('Stopwatch File Name', 'Text files (*.txt)|*.txt|All files (*.*)|*.*', 'fileName');">...</button>
+        </div>
+        <div class="sdpi-item" id="dvFilePrefix">
+            <div class="sdpi-item-label">File Title Prefix</div>
+            <input class="sdpi-item-value sdProperty" placeholder="" value="" id="filePrefix" oninput="setSettings()">
+        </div>
+        <div type="checkbox" class="sdpi-item" id="dvClearFileOnReset">
+            <div class="sdpi-item-label">Clear on Reset</div>
+            <div class="sdpi-item-value">
+                <input id="clearFileOnReset" type="checkbox" value="" class="sdProperty sdCheckbox" oninput="setSettings()">
+                <label for="clearFileOnReset" class="sdpi-item-label"><span></span>Clear text file on reset</label>
+            </div>
+        </div>
+
+        <div class="sdpi-heading">ADVANCED SETTINGS</div>
         <div class="sdpi-item" id="dvSharedId">
             <div class="sdpi-item-label">Shared Id (optional)</div>
             <input class="sdpi-item-value sdProperty" placeholder="watch1" value="" id="sharedId" oninput="setSettings()">

--- a/Stopwatch/Stopwatch.csproj
+++ b/Stopwatch/Stopwatch.csproj
@@ -35,15 +35,35 @@
     <WarningLevel>4</WarningLevel>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\Debug\com.barraider.stopwatch.sdPlugin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <LangVersion>8.0</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\Release\com.barraider.stopwatch.sdPlugin\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <LangVersion>8.0</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CommandLine, Version=2.8.0.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
-      <HintPath>..\..\..\DotNet\StreamDeck\packages\CommandLineParser.2.8.0\lib\net461\CommandLine.dll</HintPath>
+    <Reference Include="CommandLine, Version=2.9.1.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
+      <HintPath>..\..\..\DotNet\StreamDeck\packages\CommandLineParser.2.9.1\lib\net461\CommandLine.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\..\DotNet\StreamDeck\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\..\DotNet\StreamDeck\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\..\..\DotNet\StreamDeck\packages\NLog.4.7.10\lib\net45\NLog.dll</HintPath>
+    <Reference Include="NLog, Version=5.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\DotNet\StreamDeck\packages\NLog.5.3.4\lib\net46\NLog.dll</HintPath>
     </Reference>
     <Reference Include="PickersUtil">
       <HintPath>..\..\PickersUtil\PickersUtil\bin\Release\PickersUtil.dll</HintPath>
@@ -51,15 +71,15 @@
     <Reference Include="streamdeck-client-csharp, Version=4.3.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\..\DotNet\StreamDeck\packages\streamdeck-client-csharp.4.3.0\lib\netstandard2.0\streamdeck-client-csharp.dll</HintPath>
     </Reference>
-    <Reference Include="StreamDeckTools, Version=3.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\DotNet\StreamDeck\packages\StreamDeck-Tools.3.2.0\lib\net472\StreamDeckTools.dll</HintPath>
+    <Reference Include="StreamDeckTools, Version=6.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\DotNet\StreamDeck\packages\StreamDeck-Tools.6.2.0\lib\netstandard2.0\StreamDeckTools.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Drawing.Common, Version=4.0.0.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\DotNet\StreamDeck\packages\System.Drawing.Common.5.0.2\lib\net461\System.Drawing.Common.dll</HintPath>
+    <Reference Include="System.Drawing.Common, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\DotNet\StreamDeck\packages\System.Drawing.Common.9.0.0\lib\net462\System.Drawing.Common.dll</HintPath>
     </Reference>
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Runtime.Serialization" />
@@ -74,6 +94,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Backend\HelperUtils.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Backend\StopwatchManager.cs" />
@@ -120,6 +141,11 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\DotNet\BRUtils\BRUtils.csproj">
+      <Project>{cee6e699-db1f-4034-9d20-25a8ddf154cd}</Project>
+      <Name>BRUtils</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Stopwatch/Stopwatch.csproj
+++ b/Stopwatch/Stopwatch.csproj
@@ -63,23 +63,20 @@
       <HintPath>..\..\..\DotNet\StreamDeck\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=5.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\..\..\DotNet\StreamDeck\packages\NLog.5.3.4\lib\net46\NLog.dll</HintPath>
+      <HintPath>..\..\..\DotNet\StreamDeck\packages\NLog.5.4.0\lib\net46\NLog.dll</HintPath>
     </Reference>
     <Reference Include="PickersUtil">
       <HintPath>..\..\PickersUtil\PickersUtil\bin\Release\PickersUtil.dll</HintPath>
     </Reference>
-    <Reference Include="streamdeck-client-csharp, Version=4.3.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\DotNet\StreamDeck\packages\streamdeck-client-csharp.4.3.0\lib\netstandard2.0\streamdeck-client-csharp.dll</HintPath>
-    </Reference>
-    <Reference Include="StreamDeckTools, Version=6.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\DotNet\StreamDeck\packages\StreamDeck-Tools.6.2.0\lib\netstandard2.0\StreamDeckTools.dll</HintPath>
+    <Reference Include="StreamDeckTools, Version=6.3.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\DotNet\StreamDeck\packages\StreamDeck-Tools.6.3.1\lib\netstandard2.0\StreamDeckTools.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Drawing.Common, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\..\DotNet\StreamDeck\packages\System.Drawing.Common.9.0.0\lib\net462\System.Drawing.Common.dll</HintPath>
+      <HintPath>..\..\..\DotNet\StreamDeck\packages\System.Drawing.Common.9.0.1\lib\net462\System.Drawing.Common.dll</HintPath>
     </Reference>
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Runtime.Serialization" />

--- a/Stopwatch/manifest.json
+++ b/Stopwatch/manifest.json
@@ -6,7 +6,7 @@
       "States": [
         {
           "Image": "Images/bg",
-          "TitleAlignment": "bottom",
+          "TitleAlignment": "middle",
           "FontSize": "16",
           "Name": "Toggle"
         },
@@ -30,7 +30,7 @@
   "Name": "Stopwatch",
   "Icon": "Images/pluginIcon",
   "URL": "https://BarRaider.com/",
-  "Version": "1.7",
+  "Version": "1.7.1",
   "CodePath": "com.barraider.stopwatch",
   "Category": "BarRaider",
   "CategoryIcon": "Images/categoryIcon",

--- a/Stopwatch/manifest.json
+++ b/Stopwatch/manifest.json
@@ -30,7 +30,7 @@
   "Name": "Stopwatch",
   "Icon": "Images/pluginIcon",
   "URL": "https://BarRaider.com/",
-  "Version": "1.7.1",
+  "Version": "1.8",
   "CodePath": "com.barraider.stopwatch",
   "Category": "BarRaider",
   "CategoryIcon": "Images/categoryIcon",
@@ -42,6 +42,6 @@
   ],
   "SDKVersion": 2,
   "Software": {
-    "MinimumVersion": "5.0"
+    "MinimumVersion": "6.8.1"
   }
 }

--- a/Stopwatch/packages.config
+++ b/Stopwatch/packages.config
@@ -2,8 +2,7 @@
 <packages>
   <package id="CommandLineParser" version="2.9.1" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net48" />
-  <package id="NLog" version="5.3.4" targetFramework="net48" />
-  <package id="streamdeck-client-csharp" version="4.3.0" targetFramework="net472" />
-  <package id="StreamDeck-Tools" version="6.2.0" targetFramework="net48" />
-  <package id="System.Drawing.Common" version="9.0.0" targetFramework="net48" />
+  <package id="NLog" version="5.4.0" targetFramework="net48" />
+  <package id="StreamDeck-Tools" version="6.3.1" targetFramework="net48" />
+  <package id="System.Drawing.Common" version="9.0.1" targetFramework="net48" />
 </packages>

--- a/Stopwatch/packages.config
+++ b/Stopwatch/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommandLineParser" version="2.8.0" targetFramework="net472" />
-  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net472" />
-  <package id="NLog" version="4.7.10" targetFramework="net48" />
+  <package id="CommandLineParser" version="2.9.1" targetFramework="net48" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net48" />
+  <package id="NLog" version="5.3.4" targetFramework="net48" />
   <package id="streamdeck-client-csharp" version="4.3.0" targetFramework="net472" />
-  <package id="StreamDeck-Tools" version="3.2.0" targetFramework="net472" />
-  <package id="System.Drawing.Common" version="5.0.2" targetFramework="net48" />
+  <package id="StreamDeck-Tools" version="6.2.0" targetFramework="net48" />
+  <package id="System.Drawing.Common" version="9.0.0" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
* New milliseconds support for greater accuracy
* Choose from 10 different `time formats` to display as much or as less detail on the key as needed. 🔥
* New `File Title Prefix` setting allows to set chosen text before the time when saved to file (great to show some text before the time on stream!)